### PR TITLE
Add DetailSection component

### DIFF
--- a/src/components/form/detailSection.js
+++ b/src/components/form/detailSection.js
@@ -1,0 +1,16 @@
+"use client";
+
+const DetailSection = ({ title, children, className = "" }) => {
+  return (
+    <div className="mb-8">
+      <h2 className={`text-xl font-medium text-white text-center mb-4 ${className}`}>
+        {title}
+      </h2>
+      <div className="bg-white rounded-lg p-6">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default DetailSection;


### PR DESCRIPTION
Implemented a reusable DetailSection component that displays a section with a centered title and a white rounded background for its content. It accepts a title prop, children elements, and an optional className for additional styling flexibility.